### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly


### PR DESCRIPTION
This will keep the GitHub Actions up-to-date, and may also help prevent Actions self-disabling after 60 days: https://github.com/pypa/bootstrap/issues/5.